### PR TITLE
Adds two new songs to titlescreen.

### DIFF
--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -26,6 +26,8 @@
 		"https://www.youtube.com/watch?v=WcLzUZSGT6Q",						// Hans Zimmer, Benjamin Wallfisch - Mesa
 		"https://www.youtube.com/watch?v=Aj0htz_RzlY",						// Mega Drive - Converter
 		"https://www.youtube.com/watch?v=d2xkpz-26jM",						// Admiral Hippie - Clown.wmv
+	    "https://www.youtube.com/watch?v=UlHGGKgzgzI",                      // Elbow - Leaders of the Free World
+		"https://www.youtube.com/watch?v=02FVRMhKR9I",                      // Danzig - How The Gods Kill		
 		"https://www.youtube.com/watch?v=fMn30T5wEVg",						// Mike Morasky - SynTek Residential Mall (Extended by FoxOnTheRails)
 	    "https://www.youtube.com/watch?v=iB5Az3vbkYs")						// Coalescence - Risk of Rain (Cover by Nahu Pyrope)
 	


### PR DESCRIPTION
Adds two new songs to the title screen, Leaders of the Free World by Elbow, and How the Gods kill, by Danzig. I don't believe I should have to test this as it just adds two new songs to the audio player. 

Now fixed to make it add to the ticker.dm instead of config.

Changelog:
🆑
:soundadd: Added two new songs to the title screen playlist.
/🆑
